### PR TITLE
ci: Migrate TravisCI to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on:
+  push:
+jobs:
+  rspec:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Test
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.3
-before_install: gem install bundler -v 2.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in serverkit-vscode.gemspec
 gemspec
+
+gem "rake"
+gem "minitest"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 toshimaru
+Copyright (c) 2019-2024 toshimaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/toshimaru/serverkit-vscode.svg?branch=master)](https://travis-ci.org/toshimaru/serverkit-vscode)
+[![Test](https://github.com/toshimaru/serverkit-vscode/actions/workflows/test.yml/badge.svg)](https://github.com/toshimaru/serverkit-vscode/actions/workflows/test.yml)
+[![Gem Version](https://badge.fury.io/rb/serverkit-vscode.svg)](https://badge.fury.io/rb/serverkit-vscode)
 
 # serverkit-vscode
 
@@ -28,8 +29,8 @@ resources:
   - type: vscode_package
     name: GitHub.vscode-pull-request-github
   - type: vscode_package
-    name: ms-vscode.Go
-    version: 0.11.0
+    name: github.copilot
+    version: 1.156.0
 ```
 
 ## License

--- a/serverkit-vscode.gemspec
+++ b/serverkit-vscode.gemspec
@@ -25,7 +25,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "serverkit"
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
## Changes

- chore: Move development_dependency to `Gemfile`
- ci: Migrate TravisCI to GitHub Actions
- chore: Update year on LICENSE.txt
- chore: Updage badges on README