### PR TITLE
Release v0.2.0

### DIFF
--- a/lib/serverkit/vscode/version.rb
+++ b/lib/serverkit/vscode/version.rb
@@ -2,6 +2,6 @@
 
 module Serverkit
   module Vscode
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/serverkit-vscode.gemspec
+++ b/serverkit-vscode.gemspec
@@ -12,6 +12,11 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Serverkit plug-in for VSCode.}
   spec.homepage      = "https://github.com/serverkit/serverkit-vscode"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.7.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/serverkit/serverkit-vscode"
+  spec.metadata["changelog_uri"] = "https://github.com/serverkit/serverkit-vscode/releases"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This pull request updates the `serverkit-vscode` gem to prepare for a new release and improve its metadata. The most important changes include updating the version number, specifying a minimum required Ruby version, and adding metadata for better documentation and discoverability.

### Version update:
* Updated the `VERSION` constant in `lib/serverkit/vscode/version.rb` from `0.1.1` to `0.2.0` to reflect the new release.

### Gem specification improvements:
* Added a minimum required Ruby version (`>= 2.7.0`) to the gemspec to ensure compatibility.
* Enhanced the gemspec metadata by adding `homepage_uri`, `source_code_uri`, and `changelog_uri` for better documentation and discoverability on RubyGems.org.